### PR TITLE
close(clientfd) in the main thread

### DIFF
--- a/httpd.c
+++ b/httpd.c
@@ -4,6 +4,7 @@
 #define SO_REUSEADDR 2
 #define SOL_SOCKET 1
 #define O_RDONLY 0
+#define WNOHANG 1
 
 typedef unsigned short uint16_t;
 typedef unsigned int uint32_t;
@@ -19,6 +20,8 @@ typedef struct {
   char sin_zero[8];    /* 16 */
 } sockaddr_in_t;
 
+struct rusage;
+
 ssize_t read(int fd, void *buf, size_t nbyte);
 ssize_t write(int fd, const void *buf, size_t nbyte);
 int open(const char *path, int flags);
@@ -31,6 +34,7 @@ int listen(int socket, int backlog);
 int setsockopt(int socket, int level, int option_name, const void *option_value,
                socklen_t option_len);
 int fork();
+int wait4(int pid, int *wstatus, int options, struct rusage *rusage);
 void exit(int status);
 
 static size_t strlen(const char *s) {
@@ -164,6 +168,7 @@ int main(int argc, char *argv[]) {
   sock = tcp_listen(&addr, &yes, sizeof(yes));
   while (1) {
     int pid, clientfd;
+    while (wait4(-1, 0, WNOHANG, 0) > 0);
     if ((clientfd = accept(sock, 0, 0)) < 0) {
       perror("accept");
     } else if ((pid = fork()) < 0) {

--- a/start.S
+++ b/start.S
@@ -14,8 +14,7 @@ c(exit, 3)       /* 60 */
 c(fork, 3)       /* 57 */
 c(setsockopt, 4) /* 54 */
 c(listen, 1)     /* 50 */
-c(bind, 1)       /* 49 */
-c(shutdown, 5)   /* 48 */
+c(bind, 6)       /* 49 */
 c(accept, 2)     /* 43 */
 c(socket, 38)    /* 41 */
 c(close, 1)      /* 03 */

--- a/start.S
+++ b/start.S
@@ -10,6 +10,7 @@
 x:; \
   add r9,n
 
+c(wait4, 1)      /* 61 */
 c(exit, 3)       /* 60 */
 c(fork, 3)       /* 57 */
 c(setsockopt, 4) /* 54 */


### PR DESCRIPTION
the file descriptor was leaking in the listener thread, which is why you needed the call to shutdown() in the thread serving the request.

it doesn't reduce the size of the executable though, probably due to alignment requirements.

IDK enough assembly to fiddle with `httpd.asm`, but I did make a [branch](https://github.com/listeriaceae/nolibc-httpd/tree/asm) with an ugly hack on the old version in which I port this (it works but it could use a cleanup), the executable is marginally smaller in this case.