### PR TITLE
httpd.asm: remove null terminator from strings

### DIFF
--- a/httpd.asm
+++ b/httpd.asm
@@ -261,10 +261,10 @@ _start:
 ?_035:
         db "HTTP/1.1 404 Not Found"
         db 0DH, 0AH, 0DH, 0AH
-        db "404 Not Found", 0
+        db "404 Not Found"
 
 ?_036:
         db "HTTP/1.1 200 OK"
-        db 0DH, 0AH, 0DH, 0AH, 0
+        db 0DH, 0AH, 0DH, 0AH
 
 filesize      equ     $ - $$


### PR DESCRIPTION
this reduces the executable size by 2 bytes (using asm.sh).

I don't think the other strings benefit from this since they are embedded in the elf header.